### PR TITLE
Switching from running as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# 🚧 Containerized Terraria Server 🚧
+# 🚧 Containerized Terraria Server 🚧 Still very much a work in progress
 
 [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/trfc/terraria?style=flat-square)][dockerHub] [![Docker Cloud Automated build](https://img.shields.io/docker/cloud/automated/trfc/terraria?style=flat-square)][dockerHub] [![Docker Pulls](https://img.shields.io/docker/pulls/trfc/terraria?style=flat-square)][dockerHub]
 
@@ -8,9 +8,9 @@
 
 </div>
 
-## Still very much a work in progress
+## ❗ Permission Issues after pulling latest?
 
-I do use it myself though...
+See [Migration issues related to permissions](#Migration-issues-related-to-permissions) below.
 
 ## Quickstart
 
@@ -19,7 +19,7 @@ First and foremost, you're going to need Docker. Please check out [Docker's docu
 After installing docker, just run the following command and wait a few minutes:
 
 ```bash
-docker run -d -p 7777:7777 --memory=500m --mount source=terraria,target=/world --name="terraria" trfc/terraria:latest -autocreate 1 -world /world/Terrarium.wld -password PleaseChange!
+docker run -d -p 7777:7777 --memory=500m --mount source=terraria,target=/world --name="terraria" trfc/tar -autocreate 1 -world /world/Terrarium.wld -password PleaseChange!
 ```
 
 ### Explanation of the command above
@@ -55,11 +55,27 @@ If the authcode.txt file was left at its default location, the following command
 docker run --rm --mount source=terraria,target=/world --name="volumeinspect" trfc/vimtainer cat /world/authcode.txt
 ```
 
+## Migration issues related to permissions
+
+*Addressing the 84 pull as of the time of this writing...*
+
+If you are running into permission issues after updating to the latest version of this image, and **if you used the quickstart command from above**, consider running the following command:
+
+```bash
+docker run --rm -d --mount source=terraria,target=/world ubuntu chown -R 8433 world
+```
+
+This addresses a single issue: Terraria.exe now runs under user 8433, and thus needs permission/ownership of the *world* folder (arguably). The command above mounts to the "terraria" volume and makes user 8433 the owner of the *world* folder. The container then stops and removes itself (`--rm`).
+
+### Alternatively
+
+For now, you can target the `sudo` tag (`trfc/terraria:sudo`) instead of `latest`.
+
 ## Upcoming Features
 
 ✅ Password replace at startup (using jq and copied script?)
 
-⬜ Non-root user for running Mono+Terraria
+✅ Non-root user for running Mono+Terraria
 
 ⬜ Better README (with instructions)
 

--- a/source/dockerfile
+++ b/source/dockerfile
@@ -20,15 +20,10 @@ RUN apt-get update && \
     unzip tshock_$TSHOCK_VERSION.zip -d /tshock && \
     rm tshock_$TSHOCK_VERSION.zip && \
     useradd -u $TERRARIA_USER_UID $TERRARIA_USER_NAME && \
-    chown -R $TERRARIA_USER_NAME tshock/ && \ 
-    chmod -R 777 tshock/ && \
-    chmod u+x /tshock/TerrariaServer.exe && \    
-    chown -R $TERRARIA_USER_NAME world && \
-    chmod -R 777 world && \                      
-    mkdir -p /home/terraria/ && \
-    chown -R $TERRARIA_USER_NAME /home/terraria/ && \
-    chown $TERRARIA_USER_NAME /usr/local/bin/start.sh && \
-    chmod 777 /usr/local/bin/start.sh
+    chown -R $TERRARIA_USER_NAME tshock/ && chmod 700 /tshock/TerrariaServer.exe && chmod -R u+rw tshock/ && \    
+    chown -R $TERRARIA_USER_NAME world && chmod -R 700 world && \                      
+    mkdir -p /home/terraria/ && chown -R $TERRARIA_USER_NAME /home/terraria/ && \
+    chown $TERRARIA_USER_NAME /usr/local/bin/start.sh && chmod 500 /usr/local/bin/start.sh
 
 # Allow for external data
 VOLUME ["/world", "/tshock/ServerPlugins"]

--- a/source/dockerfile
+++ b/source/dockerfile
@@ -5,28 +5,37 @@ LABEL Author=JoshuaMiller
 # https://github.com/Pryaxis/TShock/releases
 ARG TSHOCK_VERSION=4.3.26 
 
+ARG TERRARIA_USER_UID=8433
+ARG TERRARIA_USER_NAME=terraria
+
+COPY default_config.json world/
+COPY start.sh /usr/local/bin/ 
+
+ADD https://github.com/NyxStudios/TShock/releases/download/v$TSHOCK_VERSION/tshock_$TSHOCK_VERSION.zip /
+
 # jq --> for finding/replacing json value easily
 # moreutils --> to leverage sponge, which makes outputing a file from the jq step easier
 RUN apt-get update && \
-    apt-get install -y jq moreutils unzip --no-install-recommends
-
-ADD https://github.com/NyxStudios/TShock/releases/download/v$TSHOCK_VERSION/tshock_$TSHOCK_VERSION.zip /
-RUN unzip tshock_$TSHOCK_VERSION.zip -d /tshock && \
+    apt-get install -y jq moreutils unzip --no-install-recommends && \    
+    unzip tshock_$TSHOCK_VERSION.zip -d /tshock && \
     rm tshock_$TSHOCK_VERSION.zip && \
-    chmod 777 /tshock/TerrariaServer.exe
+    useradd -u $TERRARIA_USER_UID $TERRARIA_USER_NAME && \
+    chown -R $TERRARIA_USER_NAME tshock/ && \ 
+    chmod -R 777 tshock/ && \
+    chmod u+x /tshock/TerrariaServer.exe && \    
+    chown -R $TERRARIA_USER_NAME world && \
+    chmod -R 777 world && \                      
+    mkdir -p /home/terraria/ && \
+    chown -R $TERRARIA_USER_NAME /home/terraria/ && \
+    chown $TERRARIA_USER_NAME /usr/local/bin/start.sh && \
+    chmod 777 /usr/local/bin/start.sh
 
 # Allow for external data
 VOLUME ["/world", "/tshock/ServerPlugins"]
 
-COPY default_config.json world/
-
 # Set working directory to server
 WORKDIR /tshock
 
-COPY start.sh /usr/local/bin/ 
-RUN chmod +x /usr/local/bin/start.sh
-
-RUN useradd -u terraria
 USER terraria
 
 # run the start script, which will set the password if provided and then run Terraria

--- a/source/dockerfile
+++ b/source/dockerfile
@@ -26,5 +26,8 @@ WORKDIR /tshock
 COPY start.sh /usr/local/bin/ 
 RUN chmod +x /usr/local/bin/start.sh
 
+RUN useradd -u terraria
+USER terraria
+
 # run the start script, which will set the password if provided and then run Terraria
 ENTRYPOINT ["start.sh"]


### PR DESCRIPTION
Running everything as root isn't a great idea, and it was on my initial list of features for this image. This PR finally adds a new user: `terraria:8433`, and runs the Terraria.exe under it. Migration of existing worlds will be needed.

# Migration issue fix

If you are running into permission issues after updating to the latest version of this image, and **if you used the quickstart command from above**, consider running the following command:

```bash
docker run --rm -d --mount source=terraria,target=/world ubuntu chown -R 8433 world
```