### PR TITLE
Add cmd and expose to dockerfile

### DIFF
--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -2,6 +2,8 @@
 FROM mono:6.8
 LABEL Author=JoshuaMiller
 
+EXPOSE 7777
+
 # https://github.com/Pryaxis/TShock/releases
 ARG TSHOCK_VERSION=4.3.26 
 
@@ -35,3 +37,4 @@ USER terraria
 
 # run the start script, which will set the password if provided and then run Terraria
 ENTRYPOINT ["start.sh"]
+CMD ["-autocreate", "1", "-world", "/world/Terrarium.wld"]


### PR DESCRIPTION
This PR adds to lines to help ease the running of this image, especially if one wants to leverage the defaults.

This is being done to help address #3. Further documentation changes could be made to assist with #3 

## CMD

With the specification of a default command, one now does not have to provide their own. This will cause the container to create a small world named Terrarium OR use an existing world named Terrarium (default Terraria server command).

## Port

If you are using the docker CLI, this allows you to pass `-P` instead of having to specify `-p 7777:7777`. Please note that using `-P` in this case assigns a random available port.

If you are using Portainer and don't want to map your own port, this allows you to select "Publish all exposed network ports to random host ports " (as shown below):

![image](https://user-images.githubusercontent.com/4266541/96940695-0cf58900-1496-11eb-8f52-68b5cca1b282.png)